### PR TITLE
Fix error in how <ul> and <li> tags were being imported

### DIFF
--- a/lib/acunetix/report_item.rb
+++ b/lib/acunetix/report_item.rb
@@ -125,7 +125,6 @@ module Acunetix
 
       result.gsub!(/<li>(.*?)<\/li>/){"\n* #{$1.strip}"}
 
-
       result
     end
 
@@ -142,7 +141,7 @@ module Acunetix
 
     # Some of the values have embedded HTML conent that we need to strip
     def tags_with_html_content
-      [:details, :description, :detailed_information, :impact]
+      [:details, :description, :detailed_information, :impact, :recommendation]
     end
 
   end

--- a/lib/acunetix/report_item.rb
+++ b/lib/acunetix/report_item.rb
@@ -121,9 +121,10 @@ module Acunetix
       result.gsub!(/<p>(.*?)<\/p>/, '\1')
       result.gsub!(/<code><pre.*?>(.*?)<\/pre><\/code>/m){|m| "\n\nbc.. #{$1.strip}\n\np.  \n" }
       result.gsub!(/<pre.*?>(.*?)<\/pre>/m){|m| "\n\nbc.. #{$1.strip}\n\np.  \n" }
-      result.gsub!(/<ul>(.*?)<\/ul>/m, '\1')
+      result.gsub!(/<ul>(.*?)<\/ul>/m){"#{$1.strip}\n"}
 
-      result.gsub!(/<li>(.*)?<\/li>/, '* \1')
+      result.gsub!(/<li>(.*?)<\/li>/){"\n* #{$1.strip}"}
+
 
       result
     end

--- a/lib/dradis/plugins/acunetix/gem_version.rb
+++ b/lib/dradis/plugins/acunetix/gem_version.rb
@@ -8,8 +8,8 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 1
-        TINY = 1
+        MINOR = 2
+        TINY = 2
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
`<ul>` and `<li>` tags were appearing in imported findings and spacing was off between list items. This fix resolves the issues so that lists are correctly formatted. 

Also added `recommendations` to the list of tags that may contain HTML tags and need to be cleaned up. 
