### PR TITLE
Prevent create_node error when a URL doesn't have "http"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Dradis Framework 3.12 (xxxx, 2018) #
+
+*   Resolves create_node errors that appeared with URLs without "http"
+
+
 ## Dradis Framework 3.11 (November, 2018) #
 
 *   No changes

--- a/lib/dradis/plugins/acunetix/gem_version.rb
+++ b/lib/dradis/plugins/acunetix/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 11
+        MINOR = 12
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/acunetix/importer.rb
+++ b/lib/dradis/plugins/acunetix/importer.rb
@@ -30,12 +30,8 @@ module Dradis::Plugins::Acunetix
     attr_accessor :scan_node
 
     def process_scan(xml_scan)
-      # Don't URI-parse simple URLs like testphp.vulnweb.com 
-      if xml_scan.at_xpath('./StartURL').text().start_with?('http')
-        start_url = URI::parse(xml_scan.at_xpath('./StartURL').text()).host
-      else
-        start_url = xml_scan.at_xpath('./StartURL').text()
-      end
+      url = xml_scan.at_xpath('./StartURL').text()
+      start_url = URI::parse(url).host || url # urls wo/ protocol returned nil
 
       self.scan_node = content_service.create_node(label: start_url, type: :host)
       logger.info{ "\tScan start URL: #{start_url}" }
@@ -54,7 +50,7 @@ module Dradis::Plugins::Acunetix
         scan_node.set_property(:web_server, xml_scan.at_xpath('./WebServer').text() )
         scan_node.set_property(:technologies, xml_scan.at_xpath('./Technologies').text() )
         scan_node.save
-      end     
+      end
 
       scan_note = template_service.process_template(template: 'scan', data: xml_scan)
       content_service.create_note text: scan_note, node: scan_node

--- a/lib/dradis/plugins/acunetix/importer.rb
+++ b/lib/dradis/plugins/acunetix/importer.rb
@@ -30,7 +30,12 @@ module Dradis::Plugins::Acunetix
     attr_accessor :scan_node
 
     def process_scan(xml_scan)
-      start_url = URI::parse(xml_scan.at_xpath('./StartURL').text()).host
+      # Don't URI-parse simple URLs like testphp.vulnweb.com 
+      if xml_scan.at_xpath('./StartURL').text().start_with?('http')
+        start_url = URI::parse(xml_scan.at_xpath('./StartURL').text()).host
+      else
+        start_url = xml_scan.at_xpath('./StartURL').text()
+      end
 
       self.scan_node = content_service.create_node(label: start_url, type: :host)
       logger.info{ "\tScan start URL: #{start_url}" }


### PR DESCRIPTION
Currently, if the `<StartURL>` tag in the Acunetix file (which determines the Node Label) is formatted like: 

`<StartURL><![CDATA[testphp.vulnweb.com]]></StartURL>` 

instead of: 

`<StartURL><![CDATA[https://testphp.vulnweb.com]]></StartURL>`

the Node will not be created properly: 
![image002](https://user-images.githubusercontent.com/11186655/50313811-31374780-0472-11e9-9048-9ec18c617cce.png)

This PR resolves this error by adding a "does it start with `http`?" check. 
