### PR TITLE
Make Request and Response fields available at the Evidence level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.23 (XXXX, 2021) #
+
+*   Make Request and Response fields available at the Evidence level
+
 ## Dradis Framework 3.22 (April, 2021) #
 
 *   No changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Dradis Framework 3.23 (XXXX, 2021) #
+## Dradis Framework 4.00 (XXXX, 2021) #
 
 *   Make Request and Response fields available at the Evidence level
 

--- a/lib/dradis/plugins/acunetix/gem_version.rb
+++ b/lib/dradis/plugins/acunetix/gem_version.rb
@@ -7,8 +7,8 @@ module Dradis
       end
 
       module VERSION
-        MAJOR = 3
-        MINOR = 22
+        MAJOR = 4
+        MINOR = 0
         TINY = 0
         PRE = nil
 

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -5,3 +5,5 @@ evidence.aop_source_file
 evidence.aop_source_line
 evidence.aop_additional
 evidence.is_false_positive
+evidence.request
+evidence.response

--- a/templates/evidence.sample
+++ b/templates/evidence.sample
@@ -9,4 +9,24 @@
   <AOP_SourceLine>0</AOP_SourceLine>
   <AOP_Additional><![CDATA[]]></AOP_Additional>
   <IsFalsePositive><![CDATA[False]]></IsFalsePositive>
+  <TechnicalDetails>
+    <Request><![CDATA[GET /hpp/params.php?p=1'%22()%26%25&lt;ScRiPt%20&gt;prompt(951846)&lt;/ScRiPt&gt;&amp;pp=1 HTTP/1.1
+Referer: http://testphp.vulnweb.com:80/
+Host: testphp.vulnweb.com
+Connection: Keep-alive
+Accept-Encoding: gzip,deflate
+User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Safari/537.36
+Accept: */*
+
+]]></Request>
+    <Response><![CDATA[HTTP/1.1 200 OK
+Server: nginx/1.4.1
+Date: Tue, 07 Oct 2014 17:30:28 GMT
+Content-Type: text/html
+Connection: keep-alive
+X-Powered-By: PHP/5.3.10-1~lucid+2uwsgi2
+Original-Content-Encoding: gzip
+Content-Length: 40
+]]></Response>
+  </TechnicalDetails>
 </ReportItem>


### PR DESCRIPTION
### Summary
Today the Acunetix fields: 

- report_item.request
- report_item.response

Are both only available at the Issue level. However, this becomes a problem when the Issue impacts >1 Node if the user wants to see the different request/response data for each instance of the issue. This PR allows both fields to be used at the Evidence level as well. 

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
