### PR TITLE
Add support for inline code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.X.X (XXXX 2023)
+  - Parse inline code, not just code blocks
+
 v4.7.1 (February 2023)
   - No changes
 

--- a/lib/acunetix/concerns/cleanup.rb
+++ b/lib/acunetix/concerns/cleanup.rb
@@ -13,6 +13,7 @@ module Acunetix
       result.gsub!(/&lt;/, '<')
       result.gsub!(/&gt;/, '>')
 
+      result.gsub!(/<h[0-9] >(.*?)<\/h[0-9]>/) { "\n\n*#{$1.strip}*\n\n" }
       result.gsub!(/<b>(.*?)<\/b>/) { "*#{$1.strip}*" }
       result.gsub!(/<br\/>/, "\n")
       result.gsub!(/<div(.*?)>|<\/div>/, '')
@@ -20,9 +21,9 @@ module Acunetix
       result.gsub!(/<font.*?>(.*?)<\/font>/m, '\1')
       result.gsub!(/<h2>(.*?)<\/h2>/) { "*#{$1.strip}*" }
       result.gsub!(/<i>(.*?)<\/i>/, '\1')
-      result.gsub!(/<p.*?>(.*?)<\/p>/) { "p. #{$1.strip}\n" }
+      result.gsub!(/<p.*?>(.*?)<\/p>/) { "\np. #{$1.strip}\n" }
       result.gsub!(/<code><pre.*?>(.*?)<\/pre><\/code>/m){|m| "\n\nbc.. #{$1.strip}\n\np.  \n" }
-      result.gsub!(/<code>(.*?)<\/code>/) { "\n\nbc. #{$1.strip}\n\n" }
+      result.gsub!(/<code>(.*?)<\/code>/) { "@#{$1.strip}@" }
       result.gsub!(/<pre.*?>(.*?)<\/pre>/m){|m| "\n\nbc.. #{$1.strip}\n\np.  \n" }
 
       result.gsub!(/<li.*?>([\s\S]*?)<\/li>/m){"\n* #{$1.strip}"}

--- a/lib/dradis/plugins/acunetix/gem_version.rb
+++ b/lib/dradis/plugins/acunetix/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 7
-        TINY = 1
+        TINY = 2
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
### Summary

This PR adds:
- support for inline code
- cleanup of `<h4 >` tags
- cleanup of lingering `p. ` tags 

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.